### PR TITLE
ConfigCommand: Allow copying the configured seed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
 	extraLibs('com.seedfinding:mc_terrain:1.0.0') {transitive = false}
 	extraLibs('com.seedfinding:mc_feature:1.0.0') {transitive = false}
 
-	extraLibs('com.seedfinding:mc_reversal:1.0.0') {transitive = false}
+	extraLibs('com.seedfinding:mc_reversal:2.0.0') {transitive = false}
 	configurations.implementation.extendsFrom(configurations.extraLibs)
 }
 

--- a/src/main/java/dev/xpple/seedmapper/command/commands/ConfigCommand.java
+++ b/src/main/java/dev/xpple/seedmapper/command/commands/ConfigCommand.java
@@ -114,7 +114,14 @@ public class ConfigCommand extends ClientCommand {
      */
     private int setSeed(CustomClientCommandSource source, long seed) {
         Config.set("seed", seed);
-        Chat.print("", new TranslatableText("command.config.setSeed", seed));
+        Chat.print("", new TranslatableText("command.config.setSeed", hover(
+            format(copy(
+                text(String.valueOf(seed)),
+                String.valueOf(seed)
+            ), Formatting.GREEN),
+            new TranslatableText("chat.copy.click")
+        )));
+
         return Command.SINGLE_SUCCESS;
     }
 
@@ -123,7 +130,13 @@ public class ConfigCommand extends ClientCommand {
         if (element instanceof JsonNull) {
             Chat.print("", new TranslatableText("command.config.getSeed.null"));
         } else {
-            Chat.print("", new TranslatableText("command.config.getSeed", element.getAsLong()));
+            Chat.print("", new TranslatableText("command.config.getSeed", hover(
+                format(copy(
+                    text(element.getAsString()),
+                    element.getAsString()
+                ), Formatting.GREEN),
+                new TranslatableText("chat.copy.click")
+            )));
         }
         return Command.SINGLE_SUCCESS;
     }


### PR DESCRIPTION
This pull request adds a click to copy functionality to `/seedmapper:config seed {get,set}`. It also fixes a broken dependency.