### PR TITLE
Added a reminder to disable Java compatibility checks in PrismLauncher

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You need to have Java 23 installed to use this mod. I recommend to get Java 23 f
 - Vanilla launcher: Go to `Installations` -> `Edit` -> `More options` -> `Java executable`.
 - MultiMC: Go to `Edit Instance` -> `Settings` -> `Java` -> `Java Installation`.
 - PrismLauncher: Go to `Settings` -> `Java` -> `Java Runtime` -> `Auto-Detect...`.
-  - Do not forget to enable "Skip Java compatibility checks" 
+  - Do not forget to enable "Skip Java compatibility checks".
 
 If you run into issues, contact your launcher's support.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ You need to have Java 23 installed to use this mod. I recommend to get Java 23 f
 - Vanilla launcher: Go to `Installations` -> `Edit` -> `More options` -> `Java executable`.
 - MultiMC: Go to `Edit Instance` -> `Settings` -> `Java` -> `Java Installation`.
 - PrismLauncher: Go to `Settings` -> `Java` -> `Java Runtime` -> `Auto-Detect...`.
+  - Don't forget to enable "Skip Java compatibility checks" 
 
 If you run into issues, contact your launcher's support.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You need to have Java 23 installed to use this mod. I recommend to get Java 23 f
 - Vanilla launcher: Go to `Installations` -> `Edit` -> `More options` -> `Java executable`.
 - MultiMC: Go to `Edit Instance` -> `Settings` -> `Java` -> `Java Installation`.
 - PrismLauncher: Go to `Settings` -> `Java` -> `Java Runtime` -> `Auto-Detect...`.
-  - Don't forget to enable "Skip Java compatibility checks" 
+  - Do not forget to enable "Skip Java compatibility checks" 
 
 If you run into issues, contact your launcher's support.
 


### PR DESCRIPTION
If this is not done, the person will not be able to launch Minecraft because Prism will prevent this with this error: 
```
This instance is not compatible with Java version 23.
Please switch to one of the following Java versions for this instance:
Java version 21
```