### PR TITLE
Add ore vein highlighting

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "src/main/c"]
 	path = src/main/c
 	url = https://github.com/xpple/cubiomes
+	branch = ore-vein-generation
 [submodule "jextract"]
 	path = jextract
 	url = https://github.com/xpple/jextract

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "src/main/c"]
 	path = src/main/c
 	url = https://github.com/xpple/cubiomes
-	branch = ore-vein-generation
 [submodule "jextract"]
 	path = jextract
 	url = https://github.com/xpple/jextract

--- a/README.md
+++ b/README.md
@@ -34,10 +34,20 @@ Usage: `/sm:locate feature structure <structure>[<pieces>]{<variants>}`.
 
 Locates a given structure closest to the player. All structures in all dimensions are supported. However, due to limitations in the underlying library, some structures (in particular desert pyramids, jungle temples and woodland mansions) may result in occasional false positives. For more advanced querying you can also use piece and variant data to further restrict the search. For example, the following command will search for end cities with ships: `/sm:locate feature structure end_city[end_ship]`.
 
+### Ore vein locating
+Usage: `/sm:locate orevein`.
+
+Locates an [ore vein](https://minecraft.wiki/w/Ore_vein) closest to the player. The coordinates of the first ore vein block found will be returned. After this, you can use [`/sm:highlight orevein [chunks]`](#ore-vein-highlighting) to highlight the other ores.
+
 ### Ore highlighting
 Usage: `/sm:highlight block <block> [chunks]`.
 
 Highlights the specified block in the world. All versions from 1.13 onwards are supported. Due to high dependence on the [`OCEAN_FLOOR_WG`](https://minecraft.wiki/w/Heightmap#OCEAN_FLOOR_WG) heightmap, coal, copper and emerald ore locations may be off.
+
+### Ore vein highlighting
+Usage: `/sm:highlight orevein [chunks]`.
+
+Highlights ore veins in the world. Raw ore blocks that generate as part of the ore vein are highlighted distinctly. Filler blocks are ignored.
 
 ### Slime chunk locating
 Usage: `/sm:locate feature slimechunk`.

--- a/includes.txt
+++ b/includes.txt
@@ -310,6 +310,7 @@
 --include-constant ClayOre
 --include-constant CoalOre
 --include-constant CopperOre
+--include-constant CopperVein
 --include-constant DEEPSLATE
 --include-constant DIAMOND_ORE
 --include-constant DIORITE
@@ -353,6 +354,7 @@
 --include-constant IRON_ORE
 --include-constant Igloo
 --include-constant IronOre
+--include-constant IronVein
 --include-constant Jungle_Pyramid
 --include-constant Jungle_Temple
 --include-constant LAPIS_ORE
@@ -384,6 +386,8 @@
 --include-constant Ocean_Ruin
 --include-constant Outpost
 --include-constant PIECE_COUNT
+--include-constant RAW_COPPER_BLOCK
+--include-constant RAW_IRON_BLOCK
 --include-constant REDSTONE_ORE
 --include-constant RedstoneOre
 --include-constant Ruined_Portal
@@ -446,6 +450,8 @@
 --include-function getMineshafts
 --include-function getOreConfig
 --include-function getOreYPos
+--include-function getOreVeinBlockAt
+--include-function getOreVeinConfig
 --include-function getParaDescent
 --include-function getParaRange
 --include-function getPossibleBiomesForLimits
@@ -454,6 +460,7 @@
 --include-function getStructurePos
 --include-function getVariant
 --include-function initFirstStronghold
+--include-function initOreVeinNoise
 --include-function isEndChunkEmpty
 --include-function isViableEndCityTerrain
 --include-function isViableFeatureBiome
@@ -468,6 +475,8 @@
 --include-struct BiomeFilter
 --include-struct EndIsland
 --include-struct OreConfig
+--include-struct OreVeinConfig
+--include-struct OreVeinParameters
 --include-struct Piece
 --include-struct Pos
 --include-struct Pos3

--- a/src/main/java/dev/xpple/seedmapper/command/CommandExceptions.java
+++ b/src/main/java/dev/xpple/seedmapper/command/CommandExceptions.java
@@ -22,6 +22,7 @@ public final class CommandExceptions {
     public static final SimpleCommandExceptionType NO_SEED_AVAILABLE_EXCEPTION = new SimpleCommandExceptionType(Component.translatable("commands.exceptions.noSeedAvailable"));
     public static final DynamicCommandExceptionType NO_BIOME_FOUND_EXCEPTION = new DynamicCommandExceptionType(arg -> Component.translatable("commands.exceptions.noBiomeFound", arg));
     public static final DynamicCommandExceptionType NO_STRUCTURE_FOUND_EXCEPTION = new DynamicCommandExceptionType(arg -> Component.translatable("commands.exceptions.noStructureFound", arg));
+    public static final DynamicCommandExceptionType NO_ORE_VEIN_FOUND_EXCEPTION = new DynamicCommandExceptionType(arg -> Component.translatable("commands.exceptions.noOreVeinFound", arg));
     public static final SimpleCommandExceptionType INVALID_DIMENSION_EXCEPTION = new SimpleCommandExceptionType(Component.translatable("commands.exceptions.invalidDimension"));
     public static final SimpleCommandExceptionType INCOMPATIBLE_PARAMETERS_EXCEPTION = new SimpleCommandExceptionType(Component.translatable("commands.exceptions.incompatibleParameters"));
 }

--- a/src/main/java/dev/xpple/seedmapper/command/CommandExceptions.java
+++ b/src/main/java/dev/xpple/seedmapper/command/CommandExceptions.java
@@ -25,4 +25,5 @@ public final class CommandExceptions {
     public static final DynamicCommandExceptionType NO_ORE_VEIN_FOUND_EXCEPTION = new DynamicCommandExceptionType(arg -> Component.translatable("commands.exceptions.noOreVeinFound", arg));
     public static final SimpleCommandExceptionType INVALID_DIMENSION_EXCEPTION = new SimpleCommandExceptionType(Component.translatable("commands.exceptions.invalidDimension"));
     public static final SimpleCommandExceptionType INCOMPATIBLE_PARAMETERS_EXCEPTION = new SimpleCommandExceptionType(Component.translatable("commands.exceptions.incompatibleParameters"));
+    public static final SimpleCommandExceptionType ORE_VEIN_WRONG_VERSION_EXCEPTION = new SimpleCommandExceptionType(Component.translatable("commands.exceptions.oreVeinWrongVersion"));
 }

--- a/src/main/java/dev/xpple/seedmapper/command/arguments/BlockArgument.java
+++ b/src/main/java/dev/xpple/seedmapper/command/arguments/BlockArgument.java
@@ -45,6 +45,8 @@ public class BlockArgument implements ArgumentType<Pair<Integer, Integer>> {
         .put("netherrack", Pair.of(Cubiomes.NETHERRACK(), MapColor.NETHER.col))
         .put("nether_gold_ore", Pair.of(Cubiomes.NETHER_GOLD_ORE(), MapColor.GOLD.col))
         .put("nether_quartz_ore", Pair.of(Cubiomes.NETHER_QUARTZ_ORE(), MapColor.QUARTZ.col))
+        .put("raw_copper_block", Pair.of(Cubiomes.RAW_COPPER_BLOCK(), MapColor.COLOR_YELLOW.col))
+        .put("raw_iron_block", Pair.of(Cubiomes.RAW_IRON_BLOCK(), MapColor.COLOR_YELLOW.col))
         .put("redstone_ore", Pair.of(Cubiomes.REDSTONE_ORE(), MapColor.FIRE.col))
         .put("soul_sand", Pair.of(Cubiomes.SOUL_SAND(), MapColor.COLOR_BROWN.col))
         .put("stone", Pair.of(Cubiomes.STONE(), MapColor.STONE.col))

--- a/src/main/java/dev/xpple/seedmapper/command/commands/HighlightCommand.java
+++ b/src/main/java/dev/xpple/seedmapper/command/commands/HighlightCommand.java
@@ -14,11 +14,11 @@ import dev.xpple.seedmapper.command.CustomClientCommandSource;
 import dev.xpple.seedmapper.config.Configs;
 import dev.xpple.seedmapper.feature.OreTypes;
 import dev.xpple.seedmapper.render.RenderManager;
+import dev.xpple.seedmapper.util.ComponentUtils;
 import dev.xpple.seedmapper.util.SpiralLoop;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.ComponentUtils;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.chunk.LevelChunkSection;
@@ -139,13 +139,7 @@ public class HighlightCommand {
                 count[0] += blockOres.size();
                 source.getClient().schedule(() -> {
                     RenderManager.drawBoxes(blockOres, colour);
-                    source.sendFeedback(Component.translatable("command.highlight.block.chunkSuccess", accent(String.valueOf(blockOres.size())), copy(
-                        hover(
-                            accent("%d %d".formatted(chunkX, chunkZ)),
-                            base(Component.translatable("chat.copy.click"))
-                        ),
-                        "%d %d".formatted(chunkX, chunkZ)
-                    )));
+                    source.sendFeedback(Component.translatable("command.highlight.block.chunkSuccess", accent(String.valueOf(blockOres.size())), ComponentUtils.formatXZ(chunkX, chunkZ)));
                 });
 
                 return false;
@@ -204,19 +198,13 @@ public class HighlightCommand {
                     int colour = BLOCKS.values().stream().filter(pair -> Objects.equals(block, pair.getFirst())).findAny().orElseThrow().getSecond();
                     RenderManager.drawBoxes(positions, colour);
                     if (block == Cubiomes.RAW_COPPER_BLOCK() || block == Cubiomes.RAW_IRON_BLOCK()) {
-                        source.getClient().schedule(() -> source.sendFeedback(Component.translatable("command.highlight.oreVein.rawBlocks", ComponentUtils.formatList(positions.stream().map(pos ->
-                            copy(
-                                hover(
-                                    accent("x: %d, y: %d, z: %d".formatted(pos.getX(), pos.getY(), pos.getZ())),
-                                    base(Component.translatable("chat.copy.click"))
-                                ),
-                                "%d %d %d".formatted(pos.getX(), pos.getY(), pos.getZ())
-                            )
-                        ).toList(), Component.literal(", ")))));
+                        source.getClient().schedule(() -> source.sendFeedback(Component.translatable("command.highlight.oreVein.rawBlocks", join(Component.literal(", "), positions.stream().map(pos -> {
+                            return ComponentUtils.formatXYZ(pos.getX(), pos.getY(), pos.getZ());
+                        })))));
                     }
                 });
 
-            source.getClient().schedule(() -> source.sendFeedback(Component.translatable("command.highlight.oreVein.success", count[0])));
+            source.getClient().schedule(() -> source.sendFeedback(Component.translatable("command.highlight.oreVein.success", accent(String.valueOf(count[0])))));
             return count[0];
         }
     }

--- a/src/main/java/dev/xpple/seedmapper/command/commands/HighlightCommand.java
+++ b/src/main/java/dev/xpple/seedmapper/command/commands/HighlightCommand.java
@@ -10,6 +10,7 @@ import com.github.cubiomes.SurfaceNoise;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.datafixers.util.Pair;
+import dev.xpple.seedmapper.command.CommandExceptions;
 import dev.xpple.seedmapper.command.CustomClientCommandSource;
 import dev.xpple.seedmapper.config.Configs;
 import dev.xpple.seedmapper.feature.OreTypes;
@@ -159,7 +160,9 @@ public class HighlightCommand {
         long seed = source.getSeed().getSecond();
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment parameters = OreVeinParameters.allocate(arena);
-            Cubiomes.initOreVeinNoise(parameters, seed, version);
+            if (Cubiomes.initOreVeinNoise(parameters, seed, version) == 0) {
+                throw CommandExceptions.ORE_VEIN_WRONG_VERSION_EXCEPTION.create();
+            }
 
             ChunkPos center = new ChunkPos(BlockPos.containing(source.getPosition()));
             Map<BlockPos, Integer> blocks = new HashMap<>();

--- a/src/main/java/dev/xpple/seedmapper/command/commands/LocateCommand.java
+++ b/src/main/java/dev/xpple/seedmapper/command/commands/LocateCommand.java
@@ -262,7 +262,9 @@ public class LocateCommand {
         long seed = source.getSeed().getSecond();
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment parameters = OreVeinParameters.allocate(arena);
-            Cubiomes.initOreVeinNoise(parameters, seed, version);
+            if (Cubiomes.initOreVeinNoise(parameters, seed, version) == 0) {
+                throw CommandExceptions.ORE_VEIN_WRONG_VERSION_EXCEPTION.create();
+            }
             ChunkPos center = new ChunkPos(BlockPos.containing(source.getPosition()));
             BlockPos[] pos = {null};
             SpiralLoop.spiral(center.x, center.z, 6400, (chunkX, chunkZ) -> {

--- a/src/main/java/dev/xpple/seedmapper/command/commands/LocateCommand.java
+++ b/src/main/java/dev/xpple/seedmapper/command/commands/LocateCommand.java
@@ -17,6 +17,7 @@ import dev.xpple.seedmapper.command.CommandExceptions;
 import dev.xpple.seedmapper.command.CustomClientCommandSource;
 import dev.xpple.seedmapper.feature.StructureChecks;
 import dev.xpple.seedmapper.feature.StructureVariantFeedbackHelper;
+import dev.xpple.seedmapper.util.ComponentUtils;
 import dev.xpple.seedmapper.util.SpiralLoop;
 import dev.xpple.seedmapper.util.TwoDTree;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
@@ -39,7 +40,6 @@ import static com.mojang.brigadier.arguments.BoolArgumentType.*;
 import static dev.xpple.seedmapper.command.arguments.BiomeArgument.*;
 import static dev.xpple.seedmapper.command.arguments.StructurePredicateArgument.*;
 import static dev.xpple.seedmapper.thread.ThreadingHelper.*;
-import static dev.xpple.seedmapper.util.ChatBuilder.*;
 import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.*;
 
 public class LocateCommand {
@@ -88,15 +88,7 @@ public class LocateCommand {
                 throw CommandExceptions.NO_BIOME_FOUND_EXCEPTION.create(BIOME_SEARCH_RADIUS);
             }
 
-            source.sendFeedback(Component.translatable("command.locate.biome.foundAt",
-                copy(
-                    hover(
-                        accent("x: %d, z: %d".formatted(pos.x(), pos.z())),
-                        base(Component.translatable("chat.copy.click"))
-                    ),
-                    "%d ~ %d".formatted(pos.x(), pos.z())
-                )
-            ));
+            source.sendFeedback(Component.translatable("command.locate.biome.foundAt", ComponentUtils.formatXZ(pos.x(), pos.z())));
             return Command.SINGLE_SUCCESS;
         }
     }
@@ -157,15 +149,7 @@ public class LocateCommand {
                 throw CommandExceptions.NO_STRUCTURE_FOUND_EXCEPTION.create(Level.MAX_LEVEL_SIZE);
             }
 
-            source.sendFeedback(Component.translatable("command.locate.feature.structure.foundAt",
-                copy(
-                    hover(
-                        accent("x: %d, z: %d".formatted(Pos.x(structurePos), Pos.z(structurePos))),
-                        base(Component.translatable("chat.copy.click"))
-                    ),
-                    "%d ~ %d".formatted(Pos.x(structurePos), Pos.z(structurePos))
-                )
-            ));
+            source.sendFeedback(Component.translatable("command.locate.feature.structure.foundAt", ComponentUtils.formatXZ(Pos.x(structurePos), Pos.z(structurePos))));
 
             if (structure == Cubiomes.End_City()) {
                 int numPieces = Cubiomes.getEndCityPieces(pieces, seed, Pos.x(structurePos) >> 4, Pos.z(structurePos) >> 4);
@@ -175,14 +159,8 @@ public class LocateCommand {
                     .findAny() // only one ship per end city
                     .map(Piece::pos)
                     .map(city -> new BlockPos(Pos3.x(city), Pos3.y(city) + 60, Pos3.z(city)))
-                    .ifPresent(city -> source.sendFeedback(Component.literal(" - ").append(Component.translatable("command.locate.feature.structure.endCity.hasShip",
-                        copy(
-                            hover(
-                                accent("x: %d, y: %d, z: %d".formatted(city.getX(), city.getY(), city.getZ())),
-                                base(Component.translatable("chat.copy.click"))
-                            ),
-                            "%d %d %d".formatted(city.getX(), city.getY(), city.getZ())
-                        )))));
+                    .ifPresent(city -> source.sendFeedback(Component.literal(" - ")
+                        .append(Component.translatable("command.locate.feature.structure.endCity.hasShip", ComponentUtils.formatXYZ(city.getX(), city.getY(), city.getZ())))));
             } else if (structure == Cubiomes.Fortress()) {
                 int numPieces = Cubiomes.getFortressPieces(pieces, 400, version, seed, Pos.x(structurePos) >> 4, Pos.z(structurePos) >> 4);
                 IntStream.range(0, numPieces)
@@ -190,14 +168,8 @@ public class LocateCommand {
                     .filter(piece -> Piece.type(piece) == Cubiomes.BRIDGE_SPAWNER())
                     .map(Piece::pos)
                     .map(monsterThrone -> new BlockPos(Pos3.x(monsterThrone), Pos3.y(monsterThrone) + 10, Pos3.z(monsterThrone)))
-                    .forEach(spawnerPos -> source.sendFeedback(Component.literal(" - ").append(Component.translatable("command.locate.feature.structure.fortress.hasSpawner",
-                        copy(
-                            hover(
-                                accent("x: %d, y: %d, z: %d".formatted(spawnerPos.getX(), spawnerPos.getY(), spawnerPos.getZ())),
-                                base(Component.translatable("chat.copy.click"))
-                            ),
-                            "%d %d %d".formatted(spawnerPos.getX(), spawnerPos.getY(), spawnerPos.getZ())
-                        )))));
+                    .forEach(spawnerPos -> source.sendFeedback(Component.literal(" - ")
+                        .append(Component.translatable("command.locate.feature.structure.fortress.hasSpawner", ComponentUtils.formatXYZ(spawnerPos.getX(), spawnerPos.getY(), spawnerPos.getZ())))));
             }
 
             if (!variantData) {
@@ -248,15 +220,7 @@ public class LocateCommand {
 
         BlockPos pos = tree.nearestTo(position.atY(0));
 
-        source.sendFeedback(chain(
-            highlight(Component.translatable("command.locate.feature.stronghold.success", copy(
-                hover(
-                    accent("x: %d, z: %d".formatted(pos.getX(), pos.getZ())),
-                    base(Component.translatable("chat.copy.click"))
-                ),
-                "%d ~ %d".formatted(pos.getX(), pos.getZ())
-            )))
-        ));
+        source.sendFeedback(Component.translatable("command.locate.feature.stronghold.success", ComponentUtils.formatXZ(pos.getX(), pos.getZ())));
         return Command.SINGLE_SUCCESS;
     }
 
@@ -275,20 +239,8 @@ public class LocateCommand {
         int blockPosX = (pos.x() << 4) + 9;
         int blockPosZ = (pos.z() << 4) + 9;
         source.sendFeedback(Component.translatable("command.locate.feature.slimeChunk.foundAt",
-            copy(
-                hover(
-                    accent("x: %d, z: %d".formatted(blockPosX, blockPosZ)),
-                    base(Component.translatable("command.locate.feature.slimeChunk.copy"))
-                ),
-                "%d ~ %d".formatted(blockPosX, blockPosZ)
-            ),
-            copy(
-                hover(
-                    accent(pos.x() + " " + pos.z()),
-                    base(Component.translatable("command.locate.feature.slimeChunk.copyChunk"))
-                ),
-                "%d %d".formatted(pos.x(), pos.z())
-            )
+            ComponentUtils.formatXZ(blockPosX, blockPosZ, Component.translatable("command.locate.feature.slimeChunk.copy")),
+            ComponentUtils.formatXZ(pos.x(), pos.z(), Component.translatable("command.locate.feature.slimeChunk.copyChunk"))
         ));
         return Command.SINGLE_SUCCESS;
     }
@@ -300,15 +252,7 @@ public class LocateCommand {
             Cubiomes.applySeed(generator, source.getDimension(), source.getSeed().getSecond());
             MemorySegment pos = Cubiomes.getSpawn(arena, generator);
 
-            source.sendFeedback(chain(
-                highlight(Component.translatable("command.locate.spawn.success", copy(
-                    hover(
-                        accent("x: %d, z: %d".formatted(Pos.x(pos), Pos.z(pos))),
-                        base(Component.translatable("chat.copy.click"))
-                    ),
-                    "%d ~ %d".formatted(Pos.x(pos), Pos.z(pos))
-                )))
-            ));
+            source.sendFeedback(Component.translatable("command.locate.spawn.success", ComponentUtils.formatXZ(Pos.x(pos), Pos.z(pos))));
             return Command.SINGLE_SUCCESS;
         }
     }
@@ -343,15 +287,7 @@ public class LocateCommand {
                 throw CommandExceptions.NO_ORE_VEIN_FOUND_EXCEPTION.create(6400);
             }
 
-            source.sendFeedback(Component.translatable("command.locate.oreVein.foundAt",
-                copy(
-                    hover(
-                        accent("x: %d, y: %d, z: %d".formatted(pos[0].getX(), pos[0].getY(), pos[0].getZ())),
-                        base(Component.translatable("command.locate.oreVein.copy"))
-                    ),
-                    "%d %d %d".formatted(pos[0].getX(), pos[0].getY(), pos[0].getZ())
-                )
-            ));
+            source.sendFeedback(Component.translatable("command.locate.oreVein.foundAt", ComponentUtils.formatXYZ(pos[0].getX(), pos[0].getY(), pos[0].getZ(), Component.translatable("command.locate.oreVein.copy"))));
 
             return Command.SINGLE_SUCCESS;
         }

--- a/src/main/java/dev/xpple/seedmapper/render/RenderManager.java
+++ b/src/main/java/dev/xpple/seedmapper/render/RenderManager.java
@@ -12,9 +12,9 @@ import net.minecraft.world.level.chunk.status.ChunkStatus;
 import net.minecraft.world.phys.Vec3;
 
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 public final class RenderManager {
@@ -24,7 +24,7 @@ public final class RenderManager {
 
     private static final Set<Line> lines = Collections.newSetFromMap(CacheBuilder.newBuilder().expireAfterWrite(Duration.ofMinutes(5)).<Line, Boolean>build().asMap());;
 
-    public static void drawBoxes(List<BlockPos> posBatch, int colour) {
+    public static void drawBoxes(Collection<BlockPos> posBatch, int colour) {
         Set<Line> lines = new HashSet<>();
 
         posBatch.forEach(pos -> {

--- a/src/main/java/dev/xpple/seedmapper/util/ChatBuilder.java
+++ b/src/main/java/dev/xpple/seedmapper/util/ChatBuilder.java
@@ -7,9 +7,8 @@ import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
 
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
 public final class ChatBuilder {
 
@@ -24,27 +23,36 @@ public final class ChatBuilder {
     private static final ChatFormatting ERROR = ChatFormatting.RED;
 
     public static MutableComponent chain(Component... components) {
-        return chain(Arrays.asList(components));
+        return chain(List.of(components));
     }
 
-    public static MutableComponent chain(List<Component> components) {
-        return ComponentUtils.appendAll(Component.empty(), components);
+    public static MutableComponent chain(List<? extends Component> components) {
+        MutableComponent result = Component.empty();
+        components.forEach(result::append);
+        return result;
     }
 
     public static MutableComponent join(Component delimiter, Component... components) {
-        return join(delimiter, Arrays.asList(components));
+        return join(delimiter, List.of(components));
     }
 
-    public static MutableComponent join(Component delimiter, List<Component> components) {
-        List<Component> elements = new ArrayList<>();
+    public static MutableComponent join(Component delimiter, Stream<? extends Component> components) {
+        return join(delimiter, components.toList());
+    }
 
-        for (int i = 0; i < components.size(); i++) {
-            elements.add(components.get(i));
-
-            if (i != components.size() - 1) elements.add(delimiter);
+    public static MutableComponent join(Component delimiter, List<? extends Component> components) {
+        MutableComponent result = Component.empty();
+        if (components.isEmpty()) {
+            return result;
+        }
+        if (components.size() == 1) {
+            return result.append(components.getFirst());
+        }
+        for (int i = 0; i < components.size() - 1; i++) {
+            result.append(components.get(i)).append(delimiter);
         }
 
-        return chain(elements);
+        return result.append(components.getLast());
     }
 
     public static MutableComponent format(MutableComponent component, ChatFormatting... formatting) {

--- a/src/main/java/dev/xpple/seedmapper/util/ComponentUtils.java
+++ b/src/main/java/dev/xpple/seedmapper/util/ComponentUtils.java
@@ -1,101 +1,13 @@
 package dev.xpple.seedmapper.util;
 
-import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-
-import java.text.NumberFormat;
-import java.util.List;
-import java.util.Random;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static dev.xpple.seedmapper.util.ChatBuilder.*;
 
 public final class ComponentUtils {
 
     private ComponentUtils() {
-    }
-
-    private static final NumberFormat numberFormat = NumberFormat.getInstance();
-
-    static {
-        numberFormat.setMaximumFractionDigits(1);
-        numberFormat.setMinimumFractionDigits(1);
-    }
-
-    public static String formatNumber(double number) {
-        return numberFormat.format(number);
-    }
-
-    public static String center(String text, int len) {
-        if (len <= text.length()) {
-            return text.substring(0, len);
-        }
-        int before = (len - text.length()) / 2;
-        if (before == 0) {
-            return String.format("%-" + len + "s", text);
-        }
-        int rest = len - before;
-        return String.format("%" + before + "s%-" + rest + "s", "", text);
-    }
-
-    public static MutableComponent formatList(List<Component> list) {
-        MutableComponent output = Component.literal("");
-
-        AtomicInteger count = new AtomicInteger(0);
-
-        list.forEach(text -> {
-            int index = count.getAndIncrement();
-
-            output
-                .append(text)
-                .append(base(index == list.size() - 1 ? "" : index == list.size() - 2 ? " and " : ", "));
-        });
-
-        return output;
-    }
-
-    public static MutableComponent appendAll(MutableComponent text, List<Component> toAppend) {
-        toAppend.forEach(text::append);
-        return text;
-    }
-
-    public static String random(int length) {
-        // 0 to z
-        int leftLimit = 48;
-        int rightLimit = 122;
-        Random random = new Random();
-
-        return random.ints(leftLimit, rightLimit + 1)
-            .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
-            .limit(length)
-            .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
-            .toString();
-    }
-
-    public static String stackTraceToString(Throwable e) {
-        StringBuilder stringBuilder = new StringBuilder();
-
-        boolean first = true;
-
-        do {
-            if (!first) {
-                e = e.getCause();
-            }
-
-            for (StackTraceElement element : e.getStackTrace()) {
-                stringBuilder.append(element.toString());
-                stringBuilder.append("\n");
-            }
-
-            first = false;
-        } while (e.getCause() != null);
-
-        return stringBuilder.toString();
-    }
-
-    public static String formatAxisDirection(Direction.AxisDirection axisDirection) {
-        return axisDirection.equals(Direction.AxisDirection.POSITIVE) ? "+" : "-";
     }
 
     public static MutableComponent formatSeed(long seed) {
@@ -105,6 +17,34 @@ public final class ComponentUtils {
                 base(Component.translatable("chat.copy.click"))
             ),
             String.valueOf(seed)
+        );
+    }
+
+    public static MutableComponent formatXZ(int x, int z) {
+        return formatXZ(x, z, Component.translatable("chat.copy.click"));
+    }
+
+    public static MutableComponent formatXZ(int x, int z, MutableComponent copyText) {
+        return copy(
+            hover(
+                accent("x: %d, z: %d".formatted(x, z)),
+                base(copyText)
+            ),
+            "%d ~ %d".formatted(x, z)
+        );
+    }
+
+    public static MutableComponent formatXYZ(int x, int y, int z) {
+        return formatXYZ(x, y, z, Component.translatable("chat.copy.click"));
+    }
+
+    public static MutableComponent formatXYZ(int x, int y, int z, MutableComponent copyText) {
+        return copy(
+            hover(
+                accent("x: %d, y: %d, z: %d".formatted(x, y, z)),
+                base(copyText)
+            ),
+            "%d %d %d".formatted(x, y, z)
         );
     }
 }

--- a/src/main/java/dev/xpple/seedmapper/util/RunnableClickEventActionHelper.java
+++ b/src/main/java/dev/xpple/seedmapper/util/RunnableClickEventActionHelper.java
@@ -19,8 +19,7 @@ public final class RunnableClickEventActionHelper {
         int randomInt;
         do {
             randomInt = random.nextInt();
-        } while (randomInt < 0 || randomInt > WritableBookContent.MAX_PAGES);
-        runnables.put(randomInt, code);
+        } while ((randomInt >= 0 && randomInt < WritableBookContent.MAX_PAGES) || runnables.putIfAbsent(randomInt, code) != null);
         return randomInt;
     }
 }

--- a/src/main/resources/assets/seedmapper/lang/en_us.json
+++ b/src/main/resources/assets/seedmapper/lang/en_us.json
@@ -13,6 +13,7 @@
   "commands.exceptions.unknownVariantKey": "Unknown structure variant key \"%s\".",
   "commands.exceptions.unknownVariantValue": "Unknown structure variant value \"%s\".",
   "commands.exceptions.noStructureFound": "Couldn't locate structure within %s blocks.",
+  "commands.exceptions.noOreVeinFound": "Couldn't locate an ore vein within %s chunks.",
   "commands.exceptions.unknownOre": "Unknown block \"%s\".",
   "commands.exceptions.incompatibleParameters": "Incompatible parameters.",
   "commands.exceptions.unknownResolutionMethod": "Unknowing resolution method \"%s\".",
@@ -58,6 +59,8 @@
   "command.locate.feature.slimeChunk.copy": "Click to copy coordinates of this slime chunk",
   "command.locate.feature.slimeChunk.copyChunk": "Click to copy chunk coordinates of this slime chunk",
   "command.locate.spawn.success": "Spawn point estimated to be at %s.",
+  "command.locate.oreVein.foundAt": "Ore vein found at %s.",
+  "command.locate.oreVein.copy": "Click to copy coordinates of this ore vein",
 
   "command.highlight.block.chunkSuccess": "Highlighted %s ores in chunk %s.",
   "command.highlight.block.success": "Highlighted %s ores in total!",

--- a/src/main/resources/assets/seedmapper/lang/en_us.json
+++ b/src/main/resources/assets/seedmapper/lang/en_us.json
@@ -16,6 +16,7 @@
   "commands.exceptions.noOreVeinFound": "Couldn't locate an ore vein within %s chunks.",
   "commands.exceptions.unknownOre": "Unknown block \"%s\".",
   "commands.exceptions.incompatibleParameters": "Incompatible parameters.",
+  "commands.exceptions.oreVeinWrongVersion": "Ore veins only exist after version 1.18!",
   "commands.exceptions.unknownResolutionMethod": "Unknowing resolution method \"%s\".",
 
   "command.checkSeed.using": "SeedMapper is using the seed %s from %s.",

--- a/src/main/resources/assets/seedmapper/lang/en_us.json
+++ b/src/main/resources/assets/seedmapper/lang/en_us.json
@@ -59,8 +59,10 @@
   "command.locate.feature.slimeChunk.copyChunk": "Click to copy chunk coordinates of this slime chunk",
   "command.locate.spawn.success": "Spawn point estimated to be at %s.",
 
-  "command.highlight.chunkSuccess": "Highlighted %s ores in chunk %s.",
-  "command.highlight.success": "Highlighted %s ores in total!",
+  "command.highlight.block.chunkSuccess": "Highlighted %s ores in chunk %s.",
+  "command.highlight.block.success": "Highlighted %s ores in total!",
+  "command.highlight.oreVein.rawBlocks": "Raw ore blocks at: %s.",
+  "command.highlight.oreVein.success": "Highlighted %s ore vein blocks!",
 
   "command.clear.success": "Cleared all renders.",
 


### PR DESCRIPTION
This PR adds the `/sm:highlight orevein` subcommand, which allows players to highlight [ore veins](https://minecraft.wiki/w/Ore_vein) based on the seed. Internally it uses [xpple/cubiomes#1](https://github.com/xpple/cubiomes/pull/1).