### PR TITLE
added condition to set yMin and yMax according to player y

### DIFF
--- a/src/main/java/dev/xpple/seedmapper/command/commands/HighlightCommand.java
+++ b/src/main/java/dev/xpple/seedmapper/command/commands/HighlightCommand.java
@@ -341,8 +341,8 @@ public class HighlightCommand {
 
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment params = TerrainNoise.allocate(arena);
-            Cubiomes.setupTerrainNoise(params, version, generatorFlags)
-            Cubiomes.initTerrainNoise(params, seed.seed(), dimension)
+            Cubiomes.setupTerrainNoise(params, version, generatorFlags);
+            Cubiomes.initTerrainNoise(params, seed.seed(), dimension);
             
             Set<BlockPos> blocks = new HashSet<>();
             int yMin;
@@ -364,7 +364,7 @@ public class HighlightCommand {
             SequenceLayout columnLayout = MemoryLayout.sequenceLayout(terrainHeight, Cubiomes.C_INT);
             MemorySegment blockStates = arena.allocate(columnLayout, (long) blockW * blockH);
             
-            Cubiomes.generateRegion(params, minChunkX, minChunkZ, chunkW, chunkH, blockStates, yMin, yMax, MemorySegment.NULL, 0):;
+            Cubiomes.generateRegion(params, minChunkX, minChunkZ, chunkW, chunkH, blockStates, yMin, yMax, MemorySegment.NULL, 0);
             
             for (int relX = 0; relX < blockW; relX++) {
                 int x = minX + relX;

--- a/src/main/java/dev/xpple/seedmapper/command/commands/HighlightCommand.java
+++ b/src/main/java/dev/xpple/seedmapper/command/commands/HighlightCommand.java
@@ -326,9 +326,6 @@ public class HighlightCommand {
     private static int highlightTerrain(CustomClientCommandSource source, int chunkRange) throws CommandSyntaxException {
         SeedIdentifier seed = source.getSeed().getSecond();
         int dimension = source.getDimension();
-        if (dimension == Cubiomes.DIM_END()) {
-            throw CommandExceptions.INVALID_DIMENSION_EXCEPTION.create();
-        }
         int version = source.getVersion();
         int generatorFlags = source.getGeneratorFlags();
 
@@ -344,13 +341,9 @@ public class HighlightCommand {
 
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment params = TerrainNoise.allocate(arena);
-            if (Cubiomes.setupTerrainNoise(params, version, generatorFlags) == 0) {
-                throw CommandExceptions.INCOMPATIBLE_PARAMETERS_EXCEPTION.create();
-            }
-            if (Cubiomes.initTerrainNoise(params, seed.seed(), dimension) == 0) {
-                throw CommandExceptions.INCOMPATIBLE_PARAMETERS_EXCEPTION.create();
-            }
-
+            Cubiomes.setupTerrainNoise(params, version, generatorFlags)
+            Cubiomes.initTerrainNoise(params, seed.seed(), dimension)
+            
             Set<BlockPos> blocks = new HashSet<>();
             int yMin;
             int yMax;
@@ -363,19 +356,16 @@ public class HighlightCommand {
                     yMin = -64;
                     yMax = terrainHighlightCutoffY;
                 }
-            } else {
+            } else {// no need to change height here as terrian in nether and end do not go above or below this rage
                 yMin = 0;
                 yMax = 128;
             }
             int terrainHeight = yMax - yMin;
             SequenceLayout columnLayout = MemoryLayout.sequenceLayout(terrainHeight, Cubiomes.C_INT);
             MemorySegment blockStates = arena.allocate(columnLayout, (long) blockW * blockH);
-            if (dimension == Cubiomes.DIM_OVERWORLD()) {
-                Cubiomes.generateRegion(params, minChunkX, minChunkZ, chunkW, chunkH, blockStates, MemorySegment.NULL, 0);
-            } else {
-                Cubiomes.generateNetherRegion(params, minChunkX, minChunkZ, chunkW, chunkH, blockStates);
-            }
-
+            
+            Cubiomes.generateRegion(params, minChunkX, minChunkZ, chunkW, chunkH, blockStates, yMin, yMax, MemorySegment.NULL, 0):;
+            
             for (int relX = 0; relX < blockW; relX++) {
                 int x = minX + relX;
                 for (int relZ = 0; relZ < blockH; relZ++) {

--- a/src/main/java/dev/xpple/seedmapper/command/commands/HighlightCommand.java
+++ b/src/main/java/dev/xpple/seedmapper/command/commands/HighlightCommand.java
@@ -354,9 +354,15 @@ public class HighlightCommand {
             Set<BlockPos> blocks = new HashSet<>();
             int yMin;
             int yMax;
+            int terrainHighlightCutoffY = 32; // idk how to add this to config things so i just hardcoded it here for now
             if (dimension == Cubiomes.DIM_OVERWORLD()) {
-                yMin = -64;
-                yMax = 320;
+                if (source.getPosition().y >= terrainHighlightCutoffY) {
+                    yMin = terrainHighlightCutoffY;
+                    yMax = 320;
+                } else {
+                    yMin = -64;
+                    yMax = terrainHighlightCutoffY;
+                }
             } else {
                 yMin = 0;
                 yMax = 128;

--- a/src/main/java/dev/xpple/seedmapper/command/commands/HighlightCommand.java
+++ b/src/main/java/dev/xpple/seedmapper/command/commands/HighlightCommand.java
@@ -354,7 +354,7 @@ public class HighlightCommand {
             Set<BlockPos> blocks = new HashSet<>();
             int yMin;
             int yMax;
-            int terrainHighlightCutoffY = 32; // idk how to add this to config things so i just hardcoded it here for now
+            int terrainHighlightCutoffY = Configs.TerrainHighlightCutoffY;
             if (dimension == Cubiomes.DIM_OVERWORLD()) {
                 if (source.getPosition().y >= terrainHighlightCutoffY) {
                     yMin = terrainHighlightCutoffY;

--- a/src/main/java/dev/xpple/seedmapper/config/Configs.java
+++ b/src/main/java/dev/xpple/seedmapper/config/Configs.java
@@ -134,7 +134,7 @@ public class Configs {
     @Config(setter = @Config.Setter("setTerrainHighlightCutoffY"))
     public static int TerrainHighlightCutoffY = 32;
     public static void setTerrainHighlightCutoffY(int terrainHighlightCutoffY) {
-        TerrainHighlightCutoffY = Mth.clamp(terrainHighlightCutoffY, -64, 320)
+        TerrainHighlightCutoffY = Mth.clamp(terrainHighlightCutoffY, -64, 320);
     }
     
     @Config(setter = @Config.Setter("setSeedMapBiomeY"), temporary = true)

--- a/src/main/java/dev/xpple/seedmapper/config/Configs.java
+++ b/src/main/java/dev/xpple/seedmapper/config/Configs.java
@@ -131,6 +131,12 @@ public class Configs {
         );
     }
 
+    @Config(setter = @Config.Setter("setTerrainHighlightCutoffY"))
+    public static int TerrainHighlightCutoffY = 32;
+    public static void setTerrainHighlightCutoffY(int terrainHighlightCutoffY) {
+        TerrainHighlightCutoffY = Mth.clamp(terrainHighlightCutoffY, -64, 320)
+    }
+    
     @Config(setter = @Config.Setter("setSeedMapBiomeY"), temporary = true)
     public static int SeedMapBiomeY = 64;
     public static void setSeedMapBiomeY(int seedMapBiomeY) {


### PR DESCRIPTION
I tried to implement what I suggested in discord 

[07:49]Vachan [MC@H], : to xpple: for this it would be nice to specify a height range away from player in config or command as i don't want to be highlighting or showing caves when im on surface and vice versa 
[07:49]Vachan [MC@H], : it would reduce compute (i think) and visual clutter from the random far down caves which i doubt ppl care about when highlighting terrain on surface and similarly in caves, i think 64 block range is good as a default (32 up and 32 down from player)
[07:50]Vachan [MC@H], : idk if this would be useful for the canyon or cave highlights as they have generally less visual clutter from overlap and what not 
 [MC@H], 
[07:57]Vachan [MC@H], : alternatively i think this is actually better if you can set a cutoff at a set y level say y=32 where if the player is above it highlights only above y 32 and if the player is below it only highlights below y 32

